### PR TITLE
Pass session as a prop into profile page

### DIFF
--- a/pages/profile.tsx
+++ b/pages/profile.tsx
@@ -3,18 +3,14 @@ import React from "react";
 import DiagnosticNavbar from "../components/DiagnosticNavbar";
 import ProfileComponent from "../components/ProfileComponent";
 
-const Profile = () => {
-  const [session, loading] = useSession();
-
+export default function Profile({session}) {
   return (
     <div>
       <DiagnosticNavbar />
       <ProfileComponent session={session} />
     </div>
   );
-};
-
-export default Profile;
+}
 
 Profile.auth = true;
 


### PR DESCRIPTION
This PR makes the profile page use the session that's passed in from server side props. Not sure if this will help with the logging out issue, but it doesn't seem to break anything right now. 