### PR TITLE
Make quiz component responsive on smaller screens + linking to node.js download tutorial + shuffle quiz questions

### DIFF
--- a/components/coding/MCQuiz.tsx
+++ b/components/coding/MCQuiz.tsx
@@ -25,11 +25,14 @@ export const MCQuiz: React.FC<MCQuiz> = ({ questionData }) => {
       setIsShaking(true);
     }
   };
-  useEffect(() => {
-    for (let i = questionData.length - 1; i > 0; i--) {
+  function shuffleArray(array) {
+    for (let i = array.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
-      [questionData[i], questionData[j]] = [questionData[j], questionData[i]];
+      [array[i], array[j]] = [array[j], array[i]];
     }
+  }
+  useEffect(() => {
+    shuffleArray(questionData);
   }, []);
 
   return (

--- a/components/coding/MCQuiz.tsx
+++ b/components/coding/MCQuiz.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { GuessData } from "../../pages/api/guessData";
 import {
   MultipleChoiceSentence,
@@ -25,6 +25,12 @@ export const MCQuiz: React.FC<MCQuiz> = ({ questionData }) => {
       setIsShaking(true);
     }
   };
+  useEffect(() => {
+    for (let i = questionData.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [questionData[i], questionData[j]] = [questionData[j], questionData[i]];
+    }
+  }, []);
 
   return (
     <>

--- a/components/questionTypes/MultipleChoiceSentence.tsx
+++ b/components/questionTypes/MultipleChoiceSentence.tsx
@@ -40,7 +40,9 @@ export const MultipleChoiceSentence: React.FC<MultipleChoiceSentenceProp> = ({
       <h1 className="font-semibold text-center text-4m"> {displayQuestion} </h1>
       <div className={`${properties}`}>
         {image &&
-          image.map((img) => <img className="sm:h-24 lg:h-64" src={img} />)}
+          image.map((img) => (
+            <img className="h-16 sm:h-24 lg:h-64" src={img} />
+          ))}
       </div>
       <div className="flex flex-row space-x-4">
         <div className="flex flex-col space-y-4">

--- a/pages/course/[courseId]/unit/Javascript/1.tsx
+++ b/pages/course/[courseId]/unit/Javascript/1.tsx
@@ -130,7 +130,13 @@ const JS1 = () => {
                 </li>
                 <li>
                   <b>4.</b> As a prerequisite to the coding challenges you'll
-                  need to install node.js
+                  need to install node.js.
+                  <a
+                    href="https://www.mathchamp.ca/course/coding/unit/warmups/1"
+                    className="font-bold text-blue-500"
+                  >
+                    Click Here to See How.
+                  </a>
                 </li>
                 <li>
                   <b>5.</b> In VS Code you will need to download an extension


### PR DESCRIPTION
This PR does:
- Makes the quiz component responsive on smaller screens
- Link warm-up page with node.js downloading tutorial to JS page
- Shuffling quiz questions 
**Small issue: the very first card is not being shuffled **


<img width="537" alt="Screen Shot 2022-01-19 at 4 18 57 PM" src="https://user-images.githubusercontent.com/79107199/150218436-9a2e9e72-0eee-4b90-87ae-e8e960dff3e9.png">
<img width="1361" alt="Screen Shot 2022-01-18 at 11 12 59 AM" src="https://user-images.githubusercontent.com/79107199/150218466-efca5a6b-ea20-49c6-b64e-de816ea67c7f.png">


<img width="718" alt="Screen Shot 2022-01-19 at 4 18 34 PM" src="https://user-images.githubusercontent.com/79107199/150218450-55e61ffc-449c-4da4-b9e0-2ec8d11ec338.png">

